### PR TITLE
Detection of Bonjour packets

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Nayef Ghattas
+Copyright (c) 2018 Nayef Ghattas, Anatole Beuzon
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/main.go
+++ b/main.go
@@ -29,21 +29,17 @@ func main() {
 	var eth layers.Ethernet
 	var ip4 layers.IPv4
 	var ip6 layers.IPv6
-	var tcp layers.TCP
+	var udp layers.UDP
 	var tag layers.Dot1Q
-	parser := gopacket.NewDecodingLayerParser(layers.LayerTypeEthernet, &tag, &eth, &ip4, &ip6, &tcp)
+	parser := gopacket.NewDecodingLayerParser(layers.LayerTypeEthernet, &tag, &eth, &ip4, &ip6, &udp)
 	decoded := []gopacket.LayerType{}
 
 	for packet := range source.Packets() {
 		parser.DecodeLayers(packet.Data(), &decoded)
-		for _, layerType := range decoded {
-			switch layerType {
-			case layers.LayerTypeDot1Q:
-				fmt.Println(tag.VLANIdentifier)
-			case layers.LayerTypeEthernet:
-				fmt.Printf("Source MAC: %v, Dest MAC: %v \n", eth.DstMAC, eth.SrcMAC)
-			case layers.LayerTypeIPv4:
-				fmt.Printf("Source IP: %v, Dest IP: %v \n", ip4.SrcIP, ip4.DstIP)
+		// Detect Bonjour packets
+		if ip4.DstIP.String() == "224.0.0.251" {
+			if udp.SrcPort == 5353 && udp.DstPort == 5353 {
+				fmt.Printf("New Bonjour packet detected from %v\n", ip4.SrcIP)
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func main() {
 	for packet := range source.Packets() {
 		parser.DecodeLayers(packet.Data(), &decoded)
 		// Detect Bonjour packets
-		if ip4.DstIP.String() == "224.0.0.251" {
+		if ip4.DstIP.String() == "224.0.0.251" || ip6.DstIP.String() == "ff02::fb" {
 			if udp.DstPort == 5353 {
 				fmt.Printf("New Bonjour packet detected from %v\n", ip4.SrcIP)
 			}

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 		parser.DecodeLayers(packet.Data(), &decoded)
 		// Detect Bonjour packets
 		if ip4.DstIP.String() == "224.0.0.251" {
-			if udp.SrcPort == 5353 && udp.DstPort == 5353 {
+			if udp.DstPort == 5353 {
 				fmt.Printf("New Bonjour packet detected from %v\n", ip4.SrcIP)
 			}
 		}


### PR DESCRIPTION
A first draft for detecting Bonjour packets.

Following [RFC 6762](https://tools.ietf.org/html/rfc6762), Bonjour packet detection relies on:
- matching destination IP to 224.0.0.251 or FF02::FB
- matching destination UDP port to 5353