### PR TITLE
Implement dns parsing

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -29,23 +30,60 @@ func main() {
 	}
 	source := gopacket.NewPacketSource(src, dec)
 
-	var eth layers.Ethernet
-	var ip4 layers.IPv4
-	var ip6 layers.IPv6
-	var udp layers.UDP
-	var tag layers.Dot1Q
-	parser := gopacket.NewDecodingLayerParser(layers.LayerTypeEthernet, &tag, &eth, &ip4, &ip6, &udp)
-	decoded := []gopacket.LayerType{}
-
 	for packet := range source.Packets() {
-		parser.DecodeLayers(packet.Data(), &decoded)
+		// // Extract DOT1Q tag
+		// var tag *layers.Dot1Q
+		// if parsedTag := packet.Layer(layers.LayerTypeDot1Q); parsedTag != nil {
+		// 	tag, _ = parsedTag.(*layers.Dot1Q)
+		// }
+
+		var ip4 layers.IPv4
+		if parsedIP := packet.Layer(layers.LayerTypeIPv4); parsedIP != nil {
+			ip4 = *parsedIP.(*layers.IPv4)
+		}
+
+		var ip6 layers.IPv6
+		if parsedIP := packet.Layer(layers.LayerTypeIPv6); parsedIP != nil {
+			ip6 = *parsedIP.(*layers.IPv6)
+		}
+
+		var udp layers.UDP
+		if parsedUDP := packet.Layer(layers.LayerTypeUDP); parsedUDP != nil {
+			udp = *parsedUDP.(*layers.UDP)
+		}
+
 		// Detect Bonjour packets
 		if ip4.DstIP.String() == "224.0.0.251" || ip6.DstIP.String() == "ff02::fb" {
 			if udp.DstPort == 5353 {
 				// Print time for logging / debugging purposes
 				fmt.Printf("[%v] New Bonjour packet detected from %v\n",
-					time.Now().Format("02/01/2006 15:04:05"), ip4.SrcIP) // Custom time layouts must use the reference time: Mon Jan 2 15:04:05 MST 2006
+					time.Now().Format("02/01/2006 15:04:05"), ip4.SrcIP.String()) // Custom time layouts must use the reference time: Mon Jan 2 15:04:05 MST 2006
+				dns, err := parseDNSPacket(udp.Payload)
+				if err != nil {
+					log.Println(err)
+				}
+				fmt.Println(formatDNSPacket(dns))
 			}
 		}
 	}
+}
+
+func parseDNSPacket(payload []byte) (layers.DNS, error) {
+	dnsParsedPacket := gopacket.NewPacket(payload, layers.LayerTypeDNS, gopacket.Default)
+	var dns layers.DNS
+	if parsedDNS := dnsParsedPacket.Layer(layers.LayerTypeDNS); parsedDNS != nil {
+		dns = *parsedDNS.(*layers.DNS)
+		return dns, nil
+	}
+	return dns, errors.New("Could not parse dns packet")
+}
+
+func formatDNSPacket(dns layers.DNS) (res string) {
+	for _, answer := range dns.Answers {
+		res += answer.String() + "\n"
+	}
+	for _, question := range dns.Questions {
+		res += fmt.Sprintf("Question: %s %s %s \n", question.Class, question.Name, question.Type)
+	}
+	return res
 }

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func main() {
 			if udp.DstPort == 5353 {
 				// Print time for logging / debugging purposes
 				fmt.Printf("[%v] New Bonjour packet detected from %v\n",
-					time.Now().Format("02/01/2006 15:04:05"), ip4.SrcIP.String()) // Custom time layouts must use the reference time: Mon Jan 2 15:04:05 MST 2006
+					time.Now().Format("02/01/2006 15:04:05"), getPacketIPSource(ip4, ip6)) // Custom time layouts must use the reference time: Mon Jan 2 15:04:05 MST 2006
 				dns, err := parseDNSPacket(udp.Payload)
 				if err != nil {
 					log.Println(err)
@@ -66,6 +66,13 @@ func main() {
 			}
 		}
 	}
+}
+
+func getPacketIPSource(ip4 layers.IPv4, ip6 layers.IPv6) string {
+	if ip4.SrcIP != nil {
+		return ip4.SrcIP.String()
+	}
+	return ip6.SrcIP.String()
 }
 
 func parseDNSPacket(payload []byte) (layers.DNS, error) {


### PR DESCRIPTION
#### What does this PR do ?

- Unpack udp payload and parse DNS contents, and formats it for logging purposes
- Avoid parsing packets twice : in the previous approach packets where already parsed and we parsed them again using `NewDecodingLayerParser`. As this method reused variables, it introduced bugs where simple dns requests would be interpreted as Bonjour packets. 

**NB:** The Dot1Q extraction is commented for the moment as it is not used yet.

cc @KSerrania @oxlay for review :eyes: 