### PR TITLE
Add default config parameter

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 
 func main() {
 	// Read config file and generate mDNS forwarding maps
-	configPath := flag.String("config", "", "Config file in TOML format")
+	configPath := flag.String("config", "", "Config file in TOML format (if not provided, ./config.toml is used)")
 	flag.Parse()
 	if *configPath == "" {
 		*configPath = "./config.toml"

--- a/main.go
+++ b/main.go
@@ -15,6 +15,9 @@ func main() {
 	// Read config file and generate mDNS forwarding maps
 	configPath := flag.String("config", "", "Config file in TOML format")
 	flag.Parse()
+	if *configPath == "" {
+		*configPath = "./config.toml"
+	}
 	cfg, err := readConfig(*configPath)
 	if err != nil {
 		log.Fatalf("Could not read configuration: %v", err)

--- a/main.go
+++ b/main.go
@@ -13,11 +13,8 @@ import (
 
 func main() {
 	// Read config file and generate mDNS forwarding maps
-	configPath := flag.String("config", "", "Config file in TOML format (if not provided, ./config.toml is used)")
+	configPath := flag.String("config", "./config.toml", "Config file in TOML format (if not provided, ./config.toml is used)")
 	flag.Parse()
-	if *configPath == "" {
-		*configPath = "./config.toml"
-	}
 	cfg, err := readConfig(*configPath)
 	if err != nil {
 		log.Fatalf("Could not read configuration: %v", err)


### PR DESCRIPTION
- When not providing the config option, use `./config.toml` as the config file