### PR TITLE
Remove gofmt simplify flag in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
   - go get github.com/fzipp/gocyclo
 
 script:
-  - test -z $(gofmt -s -l $GO_FILES)         # Fail if a .go file hasn't been formatted with gofmt
+  - test -z $(gofmt -l $GO_FILES)            # Fail if a .go file hasn't been formatted with gofmt
   - go test -v -race ./...                   # Run all the tests with the race detector enabled
   - go vet ./...                             # go vet is the official Go static analyzer
   - megacheck ./...                          # "go vet on steroids" + linter

--- a/config_test.go
+++ b/config_test.go
@@ -7,9 +7,9 @@ import (
 )
 
 var devices = map[macAddress]bonjourDevice{
-	"00:14:22:01:23:45": {OriginPool: 45, SharedPools: []uint16{42, 1042, 46}},
-	"00:14:22:01:23:46": {OriginPool: 46, SharedPools: []uint16{176, 148}},
-	"00:14:22:01:23:47": {OriginPool: 47, SharedPools: []uint16{1042, 1717, 13}},
+	"00:14:22:01:23:45": bonjourDevice{OriginPool: 45, SharedPools: []uint16{42, 1042, 46}},
+	"00:14:22:01:23:46": bonjourDevice{OriginPool: 46, SharedPools: []uint16{176, 148}},
+	"00:14:22:01:23:47": bonjourDevice{OriginPool: 47, SharedPools: []uint16{1042, 1717, 13}},
 }
 
 func TestMapByPool(t *testing.T) {

--- a/packet_test.go
+++ b/packet_test.go
@@ -70,7 +70,7 @@ func createMockmDNSPacket(isIPv4 bool, isDNSQuery bool) []byte {
 
 	if isDNSQuery {
 		dnsLayer = &layers.DNS{
-			Questions: []layers.DNSQuestion{{
+			Questions: []layers.DNSQuestion{layers.DNSQuestion{
 				Name:  []byte("example.com"),
 				Type:  layers.DNSTypeA,
 				Class: layers.DNSClassIN,
@@ -79,7 +79,7 @@ func createMockmDNSPacket(isIPv4 bool, isDNSQuery bool) []byte {
 		}
 	} else {
 		dnsLayer = &layers.DNS{
-			Answers: []layers.DNSResourceRecord{{
+			Answers: []layers.DNSResourceRecord{layers.DNSResourceRecord{
 				Name:  []byte("example.com"),
 				Type:  layers.DNSTypeA,
 				Class: layers.DNSClassIN,


### PR DESCRIPTION
The CI checked that the code complied with [`gofmt` simplification rule](https://golang.org/cmd/gofmt/#hdr-The_simplify_command). As debated earlier, it's probably not such a good idea as we may be loosing in readability.

This PR removes the simplification check.