### PR TITLE
[debug] Add pprof with -debug flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ Help on this project is very welcomed. Before submitting your contribution, plea
 
 # Debugging & Profiling
 
-A pprof server will listen on port `6060` if the you add the `-debug` flag when launching the binary.
+A pprof server will listen on port `6060` if the you use the `-debug` flag.
 
-More information about pprof is available [here](https://golang.org/pkg/net/http/pprof/)
+More information on pprof is available [here](https://golang.org/pkg/net/http/pprof/)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ Help on this project is very welcomed. Before submitting your contribution, plea
     - Add a description of your feature and reasons to add this feature,
     - Add test cases for this feature.
 
+# Debugging & Profiling
+
+A pprof server will listen on port `6060` if the you add the `-debug` flag when launching the binary.
+
+More information about pprof is available [here](https://golang.org/pkg/net/http/pprof/)
 
 ## License
 

--- a/main.go
+++ b/main.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"net/http"
+	_ "net/http/pprof"
 	"time"
 
 	"github.com/google/gopacket"
@@ -14,7 +16,14 @@ import (
 func main() {
 	// Read config file and generate mDNS forwarding maps
 	configPath := flag.String("config", "", "Config file in TOML format")
+	debug := flag.Bool("debug", false, "Enable pprof server on /debug/pprof/")
 	flag.Parse()
+
+	// Start debug server
+	if *debug {
+		go http.ListenAndServe(fmt.Sprintf("localhost:%d", 6060), nil)
+	}
+
 	cfg, err := readConfig(*configPath)
 	if err != nil {
 		log.Fatalf("Could not read configuration: %v", err)

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ func main() {
 
 	// Start debug server
 	if *debug {
-		go http.ListenAndServe(fmt.Sprintf("localhost:%d", 6060), nil)
+		go debugServer(6060)
 	}
 
 	cfg, err := readConfig(*configPath)
@@ -67,5 +67,12 @@ func main() {
 				}
 			}
 		}
+	}
+}
+
+func debugServer(port int) {
+	err := http.ListenAndServe(fmt.Sprintf("localhost:%d", port), nil)
+	if err != nil {
+		log.Fatalf("The application was started with -debug flag but could not listen on port %v: \n %s", port, err)
 	}
 }


### PR DESCRIPTION
### What this PR does

- Add `pprof` http handlers by importing "net/http/pprof".
- Add a `-debug` boolean flag. If this flag is set, it enables a `pprof` http server on port `6060`.
- Document this new flag.

It should make it easier to pinpoint the root cause of https://github.com/Gandem/bonjour-reflector/issues/20