### PR TITLE
update gopacket version to be compatible with golang 1.12.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,13 @@ before_script:
   - dep ensure -v
   - GO_FILES=$(find . -iname '*.go' -type f | grep -v /vendor/) # All the .go files, excluding vendor/
   - go get github.com/golang/lint/golint                        # Linter
-  - go get honnef.co/go/tools/cmd/megacheck                     # Badass static analyzer/linter
+  - go get honnef.co/go/tools/cmd/staticcheck                   # Badass static analyzer/linter
   - go get github.com/fzipp/gocyclo
 
 script:
   - test -z $(gofmt -l $GO_FILES)            # Fail if a .go file hasn't been formatted with gofmt
   - go test -v -race ./...                   # Run all the tests with the race detector enabled
   - go vet ./...                             # go vet is the official Go static analyzer
-  - megacheck ./...                          # "go vet on steroids" + linter
+  - staticcheck ./...                        # "go vet on steroids" + linter
   - gocyclo -over 19 $GO_FILES               # forbid code with excessively complicated functions
   - golint -set_exit_status $(go list ./...) # one last linter

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,23 +2,32 @@
 
 
 [[projects]]
+  digest = "1:b16fbfbcc20645cb419f78325bb2e85ec729b338e996a228124d68931a6f2a37"
   name = "github.com/BurntSushi/toml"
   packages = ["."]
+  pruneopts = "UT"
   revision = "b26d9c308763d68093482582cea63d69be07a0f0"
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:aa2befda6c130a48c32ef6370edd9fe5be530d0a0f6624e99a936dbaaffa7f65"
   name = "github.com/google/gopacket"
   packages = [
     ".",
     "layers",
-    "pcap"
+    "pcap",
   ]
-  revision = "157f9f84344746b9ed8ca4e92db2419ad94d4fc6"
+  pruneopts = "UT"
+  revision = "c340012d34adb8462b1e23ad4d7a73944f4224b8"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f9a7498f3b2c37e281db03ec64056d0ce93bbc68be03e70529631ab9ed876a4e"
+  input-imports = [
+    "github.com/BurntSushi/toml",
+    "github.com/google/gopacket",
+    "github.com/google/gopacket/layers",
+    "github.com/google/gopacket/pcap",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,4 +35,4 @@
 
 [[constraint]]
   name = "github.com/google/gopacket"
-  revision = "157f9f84344746b9ed8ca4e92db2419ad94d4fc6"
+  revision = "c340012d34adb8462b1e23ad4d7a73944f4224b8"


### PR DESCRIPTION
see https://github.com/google/gopacket/issues/656

fixes https://github.com/Gandem/bonjour-reflector/issues/27

also replaces `megacheck` with `staticcheck` as the former is deprecated