### PR TITLE
FIX: change src ip in mdns query (#32)

### DIFF
--- a/config.go
+++ b/config.go
@@ -11,6 +11,7 @@ type macAddress string
 type brconfig struct {
 	NetInterface string                       `toml:"net_interface"`
 	Devices      map[macAddress]bonjourDevice `toml:"devices"`
+	SpoofAddr    string                       `toml:"cc_subnet_ip"`
 }
 
 type bonjourDevice struct {

--- a/config_test.go
+++ b/config_test.go
@@ -20,6 +20,7 @@ func TestReadConfig(t *testing.T) {
 	expectedCfg := brconfig{
 		NetInterface: "test0",
 		Devices:      devices,
+		SpoofAddr:    "192.168.1.1",
 	}
 
 	if err != nil {

--- a/config_test.toml
+++ b/config_test.toml
@@ -1,5 +1,6 @@
 # This is a test config file used by config_test.go
 net_interface = "test0"
+cc_subnet_ip = "192.168.1.1"
 
 [devices]
 

--- a/main.go
+++ b/main.go
@@ -35,6 +35,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("Could not find network interface: %v", cfg.NetInterface)
 	}
+	
+	// Parse IP use to relay queries to chromecasts
+	spoofAddr := net.ParseIP(cfg.SpoofAddr)
+	if spoofAddr == nil {
+		log.Fatalf("Could not parse cc_subnet_ip")
+	}
 
 	// Get the local MAC address, to filter out Bonjour packet generated locally
 	intf, err := net.InterfaceByName(cfg.NetInterface)
@@ -66,7 +72,7 @@ func main() {
 				continue
 			}
 			for _, tag := range tags {
-				sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress)
+				sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress, spoofAddr, true)
 			}
 		} else {
 			device, ok := cfg.Devices[macAddress(bonjourPacket.srcMAC.String())]
@@ -74,7 +80,7 @@ func main() {
 				continue
 			}
 			for _, tag := range device.SharedPools {
-				sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress)
+				sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress, spoofAddr, false)
 			}
 		}
 	}

--- a/packet.go
+++ b/packet.go
@@ -12,6 +12,7 @@ type bonjourPacket struct {
 	srcMAC     *net.HardwareAddr
 	dstMAC     *net.HardwareAddr
 	isIPv6     bool
+	srcIP     *net.IP
 	vlanTag    *uint16
 	isDNSQuery bool
 }
@@ -30,10 +31,10 @@ func parsePacketsLazily(source *gopacket.PacketSource) chan bonjourPacket {
 
 			// Get source and destination mac addresses
 			srcMAC, dstMAC := parseEthernetLayer(packet)
-
-			// Check IP protocol version
-			isIPv6 := parseIPLayer(packet)
-
+			
+			// Check IP protocol version and get srcIP
+			isIPv6, srcIP := parseIPLayer(packet)
+			
 			// Get UDP payload
 			payload := parseUDPLayer(packet)
 
@@ -41,11 +42,12 @@ func parsePacketsLazily(source *gopacket.PacketSource) chan bonjourPacket {
 
 			// Pass on the packet for its next adventure
 			packetChan <- bonjourPacket{
-				packet:     packet,
+			packet:     packet,
 				vlanTag:    tag,
 				srcMAC:     srcMAC,
 				dstMAC:     dstMAC,
 				isIPv6:     isIPv6,
+				srcIP:     srcIP,
 				isDNSQuery: isDNSQuery,
 			}
 		}
@@ -69,12 +71,14 @@ func parseVLANTag(packet gopacket.Packet) (tag *uint16) {
 	return
 }
 
-func parseIPLayer(packet gopacket.Packet) (isIPv6 bool) {
+func parseIPLayer(packet gopacket.Packet) (isIPv6 bool, srcIP *net.IP) {
 	if parsedIP := packet.Layer(layers.LayerTypeIPv4); parsedIP != nil {
 		isIPv6 = false
+		srcIP = &parsedIP.(*layers.IPv4).SrcIP
 	}
 	if parsedIP := packet.Layer(layers.LayerTypeIPv6); parsedIP != nil {
 		isIPv6 = true
+		srcIP = &parsedIP.(*layers.IPv6).SrcIP
 	}
 	return
 }
@@ -98,10 +102,10 @@ type packetWriter interface {
 	WritePacketData([]byte) error
 }
 
-func sendBonjourPacket(handle packetWriter, bonjourPacket *bonjourPacket, tag uint16, brMACAddress net.HardwareAddr) {
+func sendBonjourPacket(handle packetWriter, bonjourPacket *bonjourPacket, tag uint16, brMACAddress net.HardwareAddr, spoofAddr net.IP, spoof bool) {
 	*bonjourPacket.vlanTag = tag
 	*bonjourPacket.srcMAC = brMACAddress
-
+	
 	// Network devices may set dstMAC to the local MAC address
 	// Rewrite dstMAC to ensure that it is set to the appropriate multicast MAC address
 	if bonjourPacket.isIPv6 {
@@ -109,8 +113,24 @@ func sendBonjourPacket(handle packetWriter, bonjourPacket *bonjourPacket, tag ui
 	} else {
 		*bonjourPacket.dstMAC = net.HardwareAddr{0x01, 0x00, 0x5E, 0x00, 0x00, 0xFB}
 	}
-
+	
+	
 	buf := gopacket.NewSerializeBuffer()
-	gopacket.SerializePacket(buf, gopacket.SerializeOptions{}, bonjourPacket.packet)
+	serializeOptions := gopacket.SerializeOptions{}
+	
+	// We change the Source IP address of the mDNS query since Chromecasts ignore
+	// packets coming from outside their subnet.
+	if spoof && bonjourPacket.isIPv6 == false {
+		serializeOptions = gopacket.SerializeOptions{ComputeChecksums: true}
+		*bonjourPacket.srcIP = spoofAddr
+		// We recalculate the checksum since the IP was modified
+		if parsedIP := bonjourPacket.packet.Layer(layers.LayerTypeIPv4); parsedIP != nil {
+			if parsedUDP := bonjourPacket.packet.Layer(layers.LayerTypeUDP); parsedUDP != nil {
+				parsedUDP.(*layers.UDP).SetNetworkLayerForChecksum(parsedIP.(*layers.IPv4))
+			}
+		}
+	}
+		
+	gopacket.SerializePacket(buf, serializeOptions, bonjourPacket.packet)
 	handle.WritePacketData(buf.Bytes())
 }


### PR DESCRIPTION
This adds some code to replace the the source IP of the mDNS Queries packet by an IP defined in the config file.
Chromecasts are only responding to mDNS packets originating from within their own subnet.
https://github.com/Gandem/bonjour-reflector/issues/32