### PR TITLE
Feature: Jorisjean/aggressive mode

### DIFF
--- a/config.go
+++ b/config.go
@@ -11,6 +11,7 @@ type macAddress string
 type brconfig struct {
 	NetInterface string                       `toml:"net_interface"`
 	Devices      map[macAddress]bonjourDevice `toml:"devices"`
+	SpoofAddr    string                       `toml:"cc_subnet_ip"`
 }
 
 type bonjourDevice struct {

--- a/config_test.go
+++ b/config_test.go
@@ -20,6 +20,7 @@ func TestReadConfig(t *testing.T) {
 	expectedCfg := brconfig{
 		NetInterface: "test0",
 		Devices:      devices,
+		SpoofAddr:    "192.168.1.1",
 	}
 
 	if err != nil {

--- a/config_test.toml
+++ b/config_test.toml
@@ -1,5 +1,6 @@
 # This is a test config file used by config_test.go
 net_interface = "test0"
+cc_subnet_ip = "192.168.1.1"
 
 [devices]
 

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func main() {
 	// Process Bonjours packets
 	for bonjourPacket := range bonjourPackets {
 		if *verbose {
-				fmt.Println(bonjourPacket.packet.String())
+			fmt.Println(bonjourPacket.packet.String())
 		}
 
 		// Forward the mDNS query or response to appropriate VLANs
@@ -79,8 +79,8 @@ func main() {
 			if *aggressiveMode {
 				// We store the MAC of the last client that sent a query so we can send the response directly to it
 				if clientMAC, ok := lastquery[*bonjourPacket.vlanTag]; !ok || clientMAC.String() != bonjourPacket.srcMAC.String(){
-						fmt.Printf("Storing new MAC %v for vlan %v \n", *bonjourPacket.srcMAC, *bonjourPacket.vlanTag)
-						lastquery[*bonjourPacket.vlanTag]=*bonjourPacket.srcMAC
+					fmt.Printf("Storing new MAC %v for vlan %v \n", *bonjourPacket.srcMAC, *bonjourPacket.vlanTag)
+					lastquery[*bonjourPacket.vlanTag]=*bonjourPacket.srcMAC
 				}
 			}
 

--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ func main() {
 			for _, tag := range device.SharedPools {
 				// if we have a MAC stored for this vlan we also send the response packet directly to it
 				if clientMAC, ok := lastquery[tag]; ok {
-					fmt.Printf("Sending direct packet to MAC %v \n", *bonjourPacket.srcMAC)
+					fmt.Printf("Sending direct packet to MAC %v \n", clientMAC)
 					sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress, spoofAddr, false, clientMAC)
 				}
 				// we always forward the multicast answer

--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ func main() {
 		if bonjourPacket.isDNSQuery {
 			// We store the MAC of the last client that sent a query so we can send the response directly to it
 			lastquery[*bonjourPacket.vlanTag]=*bonjourPacket.srcMAC
-			fmt.Println("Storing MAC %s for vlan %d", *bonjourPacket.srcMAC, *bonjourPacket.vlanTag)
+			fmt.Printf("Storing MAC %v for vlan %v \n", *bonjourPacket.srcMAC, *bonjourPacket.vlanTag)
 			tags, ok := poolsMap[*bonjourPacket.vlanTag]
 			if !ok {
 				continue
@@ -88,7 +88,7 @@ func main() {
 			for _, tag := range device.SharedPools {
 				// if we have a MAC stored for this vlan we also send the response packet directly to it
 				if clientMAC, ok := lastquery[tag]; ok {
-					fmt.Println("Sending direct packet to MAC %s", *bonjourPacket.srcMAC)
+					fmt.Printf("Sending direct packet to MAC %v \n", *bonjourPacket.srcMAC)
 					sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress, spoofAddr, false, clientMAC)
 				}
 				// we always forward the multicast answer

--- a/main.go
+++ b/main.go
@@ -61,7 +61,8 @@ func main() {
 	source := gopacket.NewPacketSource(rawTraffic, decoder)
 	bonjourPackets := parsePacketsLazily(source)
 
-	var lastquery map[uint16]net.HardwareAddr
+	// Map for the vlan to last MAC query
+	lastquery := make(map[uint16]net.HardwareAddr)
 
 	// Process Bonjours packets
 	for bonjourPacket := range bonjourPackets {

--- a/main.go
+++ b/main.go
@@ -35,6 +35,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("Could not find network interface: %v", cfg.NetInterface)
 	}
+	
+	// Parse IP use to relay queries to chromecasts
+	spoofAddr := net.ParseIP(cfg.SpoofAddr)
+	if spoofAddr == nil {
+		log.Fatalf("Could not parse cc_subnet_ip")
+	}
 
 	// Get the local MAC address, to filter out Bonjour packet generated locally
 	intf, err := net.InterfaceByName(cfg.NetInterface)
@@ -66,7 +72,7 @@ func main() {
 				continue
 			}
 			for _, tag := range tags {
-				sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress)
+				sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress, spoofAddr, true)
 			}
 		} else {
 			device, ok := cfg.Devices[macAddress(bonjourPacket.srcMAC.String())]
@@ -74,7 +80,7 @@ func main() {
 				continue
 			}
 			for _, tag := range device.SharedPools {
-				sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress)
+				sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress, spoofAddr, false)
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ func main() {
 			}
 
 			for _, tag := range tags {
-				sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress, spoofAddr, true, *bonjourPacket.dstMAC)
+				sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress, spoofAddr, true, *bonjourPacket.dstMAC, false)
 			}
 		} else {
 			device, ok := cfg.Devices[macAddress(bonjourPacket.srcMAC.String())]
@@ -90,10 +90,10 @@ func main() {
 				// if we have a MAC stored for this vlan we also send the response packet directly to it
 				if clientMAC, ok := lastquery[tag]; ok {
 					fmt.Printf("Sending direct packet to MAC %v \n", clientMAC)
-					sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress, spoofAddr, false, clientMAC)
+					sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress, spoofAddr, false, clientMAC, true)
 				}
 				// we always forward the multicast answer
-				sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress, spoofAddr, false, *bonjourPacket.dstMAC)
+				sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress, spoofAddr, false, *bonjourPacket.dstMAC, false)
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -1,118 +1,118 @@
 package main
 
 import (
-        "flag"
-        "fmt"
-        "log"
-        "net"
-        "net/http"
-        _ "net/http/pprof"
-        "time"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	_ "net/http/pprof"
+	"time"
 
-        "github.com/google/gopacket"
-        "github.com/google/gopacket/pcap"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/pcap"
 )
 
 func main() {
-        // Read config file and generate mDNS forwarding maps
-        configPath := flag.String("config", "", "Config file in TOML format")
-        debug := flag.Bool("debug", false, "Enable pprof server on /debug/pprof/")
-        aggressiveMode := flag.Bool("aggressivemode", false, "Also sends mdns response packet to last query packet MAC address")
-        verbose := flag.Bool("verbose", false, "Show bonjour packets")
-        flag.Parse()
+	// Read config file and generate mDNS forwarding maps
+	configPath := flag.String("config", "", "Config file in TOML format")
+	debug := flag.Bool("debug", false, "Enable pprof server on /debug/pprof/")
+	aggressiveMode := flag.Bool("aggressivemode", false, "Also sends mdns response packet to last query packet MAC address")
+	verbose := flag.Bool("verbose", false, "Show bonjour packets")
+	flag.Parse()
 
-        // Start debug server
-        if *debug {
-                go debugServer(6060)
-        }
+	// Start debug server
+	if *debug {
+		go debugServer(6060)
+	}
 
-        cfg, err := readConfig(*configPath)
-        if err != nil {
-                log.Fatalf("Could not read configuration: %v", err)
-        }
-        poolsMap := mapByPool(cfg.Devices)
+	cfg, err := readConfig(*configPath)
+	if err != nil {
+		log.Fatalf("Could not read configuration: %v", err)
+	}
+	poolsMap := mapByPool(cfg.Devices)
 
-        // Get a handle on the network interface
-        rawTraffic, err := pcap.OpenLive(cfg.NetInterface, 65536, true, time.Second)
-        if err != nil {
-                log.Fatalf("Could not find network interface: %v", cfg.NetInterface)
-        }
+	// Get a handle on the network interface
+	rawTraffic, err := pcap.OpenLive(cfg.NetInterface, 65536, true, time.Second)
+	if err != nil {
+		log.Fatalf("Could not find network interface: %v", cfg.NetInterface)
+	}
 
-        // Parse IP use to relay queries to chromecasts
-        ccSubnetIP := net.ParseIP(cfg.SpoofAddr)
-        if ccSubnetIP == nil {
-                log.Fatalf("Could not parse cc_subnet_ip")
-        }
+	// Parse IP use to relay queries to chromecasts
+	ccSubnetIP := net.ParseIP(cfg.SpoofAddr)
+	if ccSubnetIP == nil {
+		log.Fatalf("Could not parse cc_subnet_ip")
+	}
 
 
-        // Get the local MAC address, to filter out Bonjour packet generated locally
-        intf, err := net.InterfaceByName(cfg.NetInterface)
-        if err != nil {
-                log.Fatal(err)
-        }
-        brMACAddress := intf.HardwareAddr
+	// Get the local MAC address, to filter out Bonjour packet generated locally
+	intf, err := net.InterfaceByName(cfg.NetInterface)
+	if err != nil {
+		log.Fatal(err)
+	}
+	brMACAddress := intf.HardwareAddr
 
-        // Filter tagged bonjour traffic
-        filterTemplate := "not (ether src %s) and vlan and dst net (224.0.0.251 or ff02::fb) and udp dst port 5353"
-        err = rawTraffic.SetBPFFilter(fmt.Sprintf(filterTemplate, brMACAddress))
-        if err != nil {
-                log.Fatalf("Could not apply filter on network interface: %v", err)
-        }
+	// Filter tagged bonjour traffic
+	filterTemplate := "not (ether src %s) and vlan and dst net (224.0.0.251 or ff02::fb) and udp dst port 5353"
+	err = rawTraffic.SetBPFFilter(fmt.Sprintf(filterTemplate, brMACAddress))
+	if err != nil {
+		log.Fatalf("Could not apply filter on network interface: %v", err)
+	}
 
-        // Get a channel of Bonjour packets to process
-        decoder := gopacket.DecodersByLayerName["Ethernet"]
-        source := gopacket.NewPacketSource(rawTraffic, decoder)
-        bonjourPackets := parsePacketsLazily(source)
+	// Get a channel of Bonjour packets to process
+	decoder := gopacket.DecodersByLayerName["Ethernet"]
+	source := gopacket.NewPacketSource(rawTraffic, decoder)
+	bonjourPackets := parsePacketsLazily(source)
 
-        // Map for the vlan to last MAC query
-        lastquery := make(map[uint16]net.HardwareAddr)
+	// Map for the vlan to last MAC query
+	lastquery := make(map[uint16]net.HardwareAddr)
 
-        // Process Bonjours packets
-        for bonjourPacket := range bonjourPackets {
-                if *verbose {
-                        fmt.Println(bonjourPacket.packet.String())
-                }
+	// Process Bonjours packets
+	for bonjourPacket := range bonjourPackets {
+		if *verbose {
+				fmt.Println(bonjourPacket.packet.String())
+		}
 
-                // Forward the mDNS query or response to appropriate VLANs
-                if bonjourPacket.isDNSQuery {
+		// Forward the mDNS query or response to appropriate VLANs
+		if bonjourPacket.isDNSQuery {
 
-                        if *aggressiveMode {
-                                // We store the MAC of the last client that sent a query so we can send the response directly to it
-                                if clientMAC, ok := lastquery[*bonjourPacket.vlanTag]; !ok || clientMAC.String() != bonjourPacket.srcMAC.String(){
-                                        fmt.Printf("Storing new MAC %v for vlan %v \n", *bonjourPacket.srcMAC, *bonjourPacket.vlanTag)
-                                        lastquery[*bonjourPacket.vlanTag]=*bonjourPacket.srcMAC
-                                }
-                        }
+			if *aggressiveMode {
+				// We store the MAC of the last client that sent a query so we can send the response directly to it
+				if clientMAC, ok := lastquery[*bonjourPacket.vlanTag]; !ok || clientMAC.String() != bonjourPacket.srcMAC.String(){
+						fmt.Printf("Storing new MAC %v for vlan %v \n", *bonjourPacket.srcMAC, *bonjourPacket.vlanTag)
+						lastquery[*bonjourPacket.vlanTag]=*bonjourPacket.srcMAC
+				}
+			}
 
-                        tags, ok := poolsMap[*bonjourPacket.vlanTag]
-                        if !ok {
-                                continue
-                        }
+			tags, ok := poolsMap[*bonjourPacket.vlanTag]
+			if !ok {
+				continue
+			}
 
-                        for _, tag := range tags {
-                                sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress, ccSubnetIP, true, *bonjourPacket.dstMAC, false)
-                        }
-                } else {
-                        device, ok := cfg.Devices[macAddress(bonjourPacket.srcMAC.String())]
-                        if !ok {
-                                continue
-                        }
-                        for _, tag := range device.SharedPools {
-                                // if we have a MAC stored for this vlan we also send the response packet directly to it
-                                if clientMAC, ok := lastquery[tag]; ok {
-                                        fmt.Printf("Sending direct packet to MAC %v \n", clientMAC)
-                                        sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress, *bonjourPacket.srcIP, false, clientMAC, true)
-                                }
-                                // we always forward the multicast answer
-                                sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress, *bonjourPacket.srcIP, false, *bonjourPacket.dstMAC, false)
-                        }
-                }
-        }
+			for _, tag := range tags {
+				sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress, ccSubnetIP, true, *bonjourPacket.dstMAC, false)
+			}
+		} else {
+			device, ok := cfg.Devices[macAddress(bonjourPacket.srcMAC.String())]
+			if !ok {
+				continue
+			}
+			for _, tag := range device.SharedPools {
+				// if we have a MAC stored for this vlan we also send the response packet directly to it
+				if clientMAC, ok := lastquery[tag]; ok {
+					fmt.Printf("Sending direct packet to MAC %v \n", clientMAC)
+					sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress, *bonjourPacket.srcIP, false, clientMAC, true)
+				}
+				// we always forward the multicast answer
+				sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress, *bonjourPacket.srcIP, false, *bonjourPacket.dstMAC, false)
+			}
+		}
+	}
 }
 
 func debugServer(port int) {
-        err := http.ListenAndServe(fmt.Sprintf("localhost:%d", port), nil)
-        if err != nil {
-                log.Fatalf("The application was started with -debug flag but could not listen on port %v: \n %s", port, err)
-        }
+	err := http.ListenAndServe(fmt.Sprintf("localhost:%d", port), nil)
+	if err != nil {
+		log.Fatalf("The application was started with -debug flag but could not listen on port %v: \n %s", port, err)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func main() {
 	source := gopacket.NewPacketSource(rawTraffic, decoder)
 	bonjourPackets := parsePacketsLazily(source)
 
-	var lastquery map[int]net.IP //map using var
+	var lastquery map[uint16]net.HardwareAddr
 
 	// Process Bonjours packets
 	for bonjourPacket := range bonjourPackets {

--- a/main.go
+++ b/main.go
@@ -1,118 +1,118 @@
 package main
 
 import (
-	"flag"
-	"fmt"
-	"log"
-	"net"
-	"net/http"
-	_ "net/http/pprof"
-	"time"
+        "flag"
+        "fmt"
+        "log"
+        "net"
+        "net/http"
+        _ "net/http/pprof"
+        "time"
 
-	"github.com/google/gopacket"
-	"github.com/google/gopacket/pcap"
+        "github.com/google/gopacket"
+        "github.com/google/gopacket/pcap"
 )
 
 func main() {
-	// Read config file and generate mDNS forwarding maps
-	configPath := flag.String("config", "", "Config file in TOML format")
-	debug := flag.Bool("debug", false, "Enable pprof server on /debug/pprof/")
-	aggressiveMode := flag.Bool("aggressivemode", false, "Also sends mdns response packet to last query packet MAC address")
-	verbose := flag.Bool("verbose", false, "Show bonjour packets")
-	flag.Parse()
+        // Read config file and generate mDNS forwarding maps
+        configPath := flag.String("config", "", "Config file in TOML format")
+        debug := flag.Bool("debug", false, "Enable pprof server on /debug/pprof/")
+        aggressiveMode := flag.Bool("aggressivemode", false, "Also sends mdns response packet to last query packet MAC address")
+        verbose := flag.Bool("verbose", false, "Show bonjour packets")
+        flag.Parse()
 
-	// Start debug server
-	if *debug {
-		go debugServer(6060)
-	}
+        // Start debug server
+        if *debug {
+                go debugServer(6060)
+        }
 
-	cfg, err := readConfig(*configPath)
-	if err != nil {
-		log.Fatalf("Could not read configuration: %v", err)
-	}
-	poolsMap := mapByPool(cfg.Devices)
+        cfg, err := readConfig(*configPath)
+        if err != nil {
+                log.Fatalf("Could not read configuration: %v", err)
+        }
+        poolsMap := mapByPool(cfg.Devices)
 
-	// Get a handle on the network interface
-	rawTraffic, err := pcap.OpenLive(cfg.NetInterface, 65536, true, time.Second)
-	if err != nil {
-		log.Fatalf("Could not find network interface: %v", cfg.NetInterface)
-	}
-	
-	// Parse IP use to relay queries to chromecasts
-	ccSubnetIP := net.ParseIP(cfg.SpoofAddr)
-	if ccSubnetIP == nil {
-		log.Fatalf("Could not parse cc_subnet_ip")
-	}
+        // Get a handle on the network interface
+        rawTraffic, err := pcap.OpenLive(cfg.NetInterface, 65536, true, time.Second)
+        if err != nil {
+                log.Fatalf("Could not find network interface: %v", cfg.NetInterface)
+        }
+
+        // Parse IP use to relay queries to chromecasts
+        ccSubnetIP := net.ParseIP(cfg.SpoofAddr)
+        if ccSubnetIP == nil {
+                log.Fatalf("Could not parse cc_subnet_ip")
+        }
 
 
-	// Get the local MAC address, to filter out Bonjour packet generated locally
-	intf, err := net.InterfaceByName(cfg.NetInterface)
-	if err != nil {
-		log.Fatal(err)
-	}
-	brMACAddress := intf.HardwareAddr
+        // Get the local MAC address, to filter out Bonjour packet generated locally
+        intf, err := net.InterfaceByName(cfg.NetInterface)
+        if err != nil {
+                log.Fatal(err)
+        }
+        brMACAddress := intf.HardwareAddr
 
-	// Filter tagged bonjour traffic
-	filterTemplate := "not (ether src %s) and vlan and dst net (224.0.0.251 or ff02::fb) and udp dst port 5353"
-	err = rawTraffic.SetBPFFilter(fmt.Sprintf(filterTemplate, brMACAddress))
-	if err != nil {
-		log.Fatalf("Could not apply filter on network interface: %v", err)
-	}
+        // Filter tagged bonjour traffic
+        filterTemplate := "not (ether src %s) and vlan and dst net (224.0.0.251 or ff02::fb) and udp dst port 5353"
+        err = rawTraffic.SetBPFFilter(fmt.Sprintf(filterTemplate, brMACAddress))
+        if err != nil {
+                log.Fatalf("Could not apply filter on network interface: %v", err)
+        }
 
-	// Get a channel of Bonjour packets to process
-	decoder := gopacket.DecodersByLayerName["Ethernet"]
-	source := gopacket.NewPacketSource(rawTraffic, decoder)
-	bonjourPackets := parsePacketsLazily(source)
+        // Get a channel of Bonjour packets to process
+        decoder := gopacket.DecodersByLayerName["Ethernet"]
+        source := gopacket.NewPacketSource(rawTraffic, decoder)
+        bonjourPackets := parsePacketsLazily(source)
 
-	// Map for the vlan to last MAC query
-	lastquery := make(map[uint16]net.HardwareAddr)
+        // Map for the vlan to last MAC query
+        lastquery := make(map[uint16]net.HardwareAddr)
 
-	// Process Bonjours packets
-	for bonjourPacket := range bonjourPackets {
-		if *verbose {
-			fmt.Println(bonjourPacket.packet.String())
-		}
+        // Process Bonjours packets
+        for bonjourPacket := range bonjourPackets {
+                if *verbose {
+                        fmt.Println(bonjourPacket.packet.String())
+                }
 
-		// Forward the mDNS query or response to appropriate VLANs
-		if bonjourPacket.isDNSQuery {
+                // Forward the mDNS query or response to appropriate VLANs
+                if bonjourPacket.isDNSQuery {
 
-			if *aggressiveMode {
-				// We store the MAC of the last client that sent a query so we can send the response directly to it
-				if clientMAC, ok := lastquery[*bonjourPacket.vlanTag]; !ok || clientMAC != *bonjourPacket.srcMAC {
-					fmt.Printf("Storing new MAC %v for vlan %v \n", *bonjourPacket.srcMAC, *bonjourPacket.vlanTag)
-					lastquery[*bonjourPacket.vlanTag]=*bonjourPacket.srcMAC
-				}
-			}
+                        if *aggressiveMode {
+                                // We store the MAC of the last client that sent a query so we can send the response directly to it
+                                if clientMAC, ok := lastquery[*bonjourPacket.vlanTag]; !ok || clientMAC.String() != bonjourPacket.srcMAC.String(){
+                                        fmt.Printf("Storing new MAC %v for vlan %v \n", *bonjourPacket.srcMAC, *bonjourPacket.vlanTag)
+                                        lastquery[*bonjourPacket.vlanTag]=*bonjourPacket.srcMAC
+                                }
+                        }
 
-			tags, ok := poolsMap[*bonjourPacket.vlanTag]
-			if !ok {
-				continue
-			}
+                        tags, ok := poolsMap[*bonjourPacket.vlanTag]
+                        if !ok {
+                                continue
+                        }
 
-			for _, tag := range tags {
-				sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress, ccSubnetIP, true, *bonjourPacket.dstMAC, false)
-			}
-		} else {
-			device, ok := cfg.Devices[macAddress(bonjourPacket.srcMAC.String())]
-			if !ok {
-				continue
-			}
-			for _, tag := range device.SharedPools {
-				// if we have a MAC stored for this vlan we also send the response packet directly to it
-				if clientMAC, ok := lastquery[tag]; ok {
-					fmt.Printf("Sending direct packet to MAC %v \n", clientMAC)
-					sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress, *bonjourPacket.srcIP, false, clientMAC, true)
-				}
-				// we always forward the multicast answer
-				sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress, *bonjourPacket.srcIP, false, *bonjourPacket.dstMAC, false)
-			}
-		}
-	}
+                        for _, tag := range tags {
+                                sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress, ccSubnetIP, true, *bonjourPacket.dstMAC, false)
+                        }
+                } else {
+                        device, ok := cfg.Devices[macAddress(bonjourPacket.srcMAC.String())]
+                        if !ok {
+                                continue
+                        }
+                        for _, tag := range device.SharedPools {
+                                // if we have a MAC stored for this vlan we also send the response packet directly to it
+                                if clientMAC, ok := lastquery[tag]; ok {
+                                        fmt.Printf("Sending direct packet to MAC %v \n", clientMAC)
+                                        sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress, *bonjourPacket.srcIP, false, clientMAC, true)
+                                }
+                                // we always forward the multicast answer
+                                sendBonjourPacket(rawTraffic, &bonjourPacket, tag, brMACAddress, *bonjourPacket.srcIP, false, *bonjourPacket.dstMAC, false)
+                        }
+                }
+        }
 }
 
 func debugServer(port int) {
-	err := http.ListenAndServe(fmt.Sprintf("localhost:%d", port), nil)
-	if err != nil {
-		log.Fatalf("The application was started with -debug flag but could not listen on port %v: \n %s", port, err)
-	}
+        err := http.ListenAndServe(fmt.Sprintf("localhost:%d", port), nil)
+        if err != nil {
+                log.Fatalf("The application was started with -debug flag but could not listen on port %v: \n %s", port, err)
+        }
 }

--- a/packet.go
+++ b/packet.go
@@ -13,6 +13,7 @@ type bonjourPacket struct {
 	dstMAC     *net.HardwareAddr
 	isIPv6     bool
 	srcIP     *net.IP
+	dstIP     *net.IP
 	vlanTag    *uint16
 	isDNSQuery bool
 }
@@ -110,20 +111,23 @@ func sendBonjourPacket(
 	brMACAddress net.HardwareAddr,
 	srcIPAddress net.IP,
 	spoofsrcIP bool,
-	dstMACAddress net.HardwareAddr) {
+	dstMACAddress net.HardwareAddr,
+	spoofdstMAC bool) {
 	*bonjourPacket.vlanTag = tag
 	*bonjourPacket.srcMAC = brMACAddress
-	*bonjourPacket.dstMAC = dstMACAddress
+	
 
 	
 	// Network devices may set dstMAC to the local MAC address
 	// Rewrite dstMAC to ensure that it is set to the appropriate multicast MAC address
 	if bonjourPacket.isIPv6 {
 		*bonjourPacket.dstMAC = net.HardwareAddr{0x33, 0x33, 0x00, 0x00, 0x00, 0xFB}
+	} else if spoofdstMAC && bonjourPacket.isIPv6 == false {
+		*bonjourPacket.dstMAC = dstMACAddress
 	} else {
 		*bonjourPacket.dstMAC = net.HardwareAddr{0x01, 0x00, 0x5E, 0x00, 0x00, 0xFB}
 	}
-	
+	 
 	
 	buf := gopacket.NewSerializeBuffer()
 	serializeOptions := gopacket.SerializeOptions{}

--- a/packet.go
+++ b/packet.go
@@ -13,7 +13,6 @@ type bonjourPacket struct {
 	dstMAC     *net.HardwareAddr
 	isIPv6     bool
 	srcIP     *net.IP
-	dstIP     *net.IP
 	vlanTag    *uint16
 	isDNSQuery bool
 }

--- a/packet.go
+++ b/packet.go
@@ -114,14 +114,13 @@ func sendBonjourPacket(
 	spoofdstMAC bool) {
 	*bonjourPacket.vlanTag = tag
 	*bonjourPacket.srcMAC = brMACAddress
-	
-
-	
+		
 	// Network devices may set dstMAC to the local MAC address
 	// Rewrite dstMAC to ensure that it is set to the appropriate multicast MAC address
+	// or Rewrite dstMAC to the specified one
 	if bonjourPacket.isIPv6 {
 		*bonjourPacket.dstMAC = net.HardwareAddr{0x33, 0x33, 0x00, 0x00, 0x00, 0xFB}
-	} else if spoofdstMAC && bonjourPacket.isIPv6 == false {
+	} else if spoofdstMAC && !bonjourPacket.isIPv6{
 		*bonjourPacket.dstMAC = dstMACAddress
 	} else {
 		*bonjourPacket.dstMAC = net.HardwareAddr{0x01, 0x00, 0x5E, 0x00, 0x00, 0xFB}
@@ -133,7 +132,7 @@ func sendBonjourPacket(
 	
 	// We change the Source IP address of the mDNS query since Chromecasts ignore
 	// packets coming from outside their subnet.
-	if spoofsrcIP && bonjourPacket.isIPv6 == false {
+	if spoofsrcIP && !bonjourPacket.isIPv6{
 		serializeOptions = gopacket.SerializeOptions{ComputeChecksums: true}
 		*bonjourPacket.srcIP = srcIPAddress
 		// We recalculate the checksum since the IP was modified

--- a/packet.go
+++ b/packet.go
@@ -12,6 +12,7 @@ type bonjourPacket struct {
 	srcMAC     *net.HardwareAddr
 	dstMAC     *net.HardwareAddr
 	isIPv6     bool
+	srcIP     *net.IP
 	vlanTag    *uint16
 	isDNSQuery bool
 }
@@ -30,10 +31,10 @@ func parsePacketsLazily(source *gopacket.PacketSource) chan bonjourPacket {
 
 			// Get source and destination mac addresses
 			srcMAC, dstMAC := parseEthernetLayer(packet)
-
-			// Check IP protocol version
-			isIPv6 := parseIPLayer(packet)
-
+			
+			// Check IP protocol version and get srcIP
+			isIPv6, srcIP := parseIPLayer(packet)
+			
 			// Get UDP payload
 			payload := parseUDPLayer(packet)
 
@@ -41,11 +42,12 @@ func parsePacketsLazily(source *gopacket.PacketSource) chan bonjourPacket {
 
 			// Pass on the packet for its next adventure
 			packetChan <- bonjourPacket{
-				packet:     packet,
+			packet:     packet,
 				vlanTag:    tag,
 				srcMAC:     srcMAC,
 				dstMAC:     dstMAC,
 				isIPv6:     isIPv6,
+				srcIP:     srcIP,
 				isDNSQuery: isDNSQuery,
 			}
 		}
@@ -69,12 +71,14 @@ func parseVLANTag(packet gopacket.Packet) (tag *uint16) {
 	return
 }
 
-func parseIPLayer(packet gopacket.Packet) (isIPv6 bool) {
+func parseIPLayer(packet gopacket.Packet) (isIPv6 bool, srcIP *net.IP) {
 	if parsedIP := packet.Layer(layers.LayerTypeIPv4); parsedIP != nil {
 		isIPv6 = false
+		srcIP = &parsedIP.(*layers.IPv4).SrcIP
 	}
 	if parsedIP := packet.Layer(layers.LayerTypeIPv6); parsedIP != nil {
 		isIPv6 = true
+		srcIP = &parsedIP.(*layers.IPv6).SrcIP
 	}
 	return
 }
@@ -98,10 +102,10 @@ type packetWriter interface {
 	WritePacketData([]byte) error
 }
 
-func sendBonjourPacket(handle packetWriter, bonjourPacket *bonjourPacket, tag uint16, brMACAddress net.HardwareAddr) {
+func sendBonjourPacket(handle packetWriter, bonjourPacket *bonjourPacket, tag uint16, brMACAddress net.HardwareAddr, spoofAddr net.IP, spoof bool) {
 	*bonjourPacket.vlanTag = tag
 	*bonjourPacket.srcMAC = brMACAddress
-
+	
 	// Network devices may set dstMAC to the local MAC address
 	// Rewrite dstMAC to ensure that it is set to the appropriate multicast MAC address
 	if bonjourPacket.isIPv6 {
@@ -109,8 +113,24 @@ func sendBonjourPacket(handle packetWriter, bonjourPacket *bonjourPacket, tag ui
 	} else {
 		*bonjourPacket.dstMAC = net.HardwareAddr{0x01, 0x00, 0x5E, 0x00, 0x00, 0xFB}
 	}
-
+	
+	
 	buf := gopacket.NewSerializeBuffer()
-	gopacket.SerializePacket(buf, gopacket.SerializeOptions{}, bonjourPacket.packet)
+	serializeOptions := gopacket.SerializeOptions{}
+	
+	// We change the Source IP address of the mDNS query since Chromecasts ignore
+	// packets coming from outside their subnet.
+	if spoof && bonjourPacket.isIPv6 == false {
+		serializeOptions = gopacket.SerializeOptions{ComputeChecksums: true}
+		*bonjourPacket.srcIP = spoofAddr
+		// We recalculate the checksum since the IP was modified
+		if parsedIP := bonjourPacket.packet.Layer(layers.LayerTypeIPv4); parsedIP != nil {
+			if parsedUDP := bonjourPacket.packet.Layer(layers.LayerTypeUDP); parsedUDP != nil {
+				parsedUDP.(*layers.UDP).SetNetworkLayerForChecksum(parsedIP.(*layers.IPv4))
+			}
+		}
+	}
+		
+	gopacket.SerializePacket(buf, serializeOptions, bonjourPacket.packet)
 	handle.WritePacketData(buf.Bytes())
 }

--- a/packet.go
+++ b/packet.go
@@ -130,9 +130,9 @@ func sendBonjourPacket(
 	
 	// We change the Source IP address of the mDNS query since Chromecasts ignore
 	// packets coming from outside their subnet.
-	if spoof && bonjourPacket.isIPv6 == false {
+	if spoofsrcIP && bonjourPacket.isIPv6 == false {
 		serializeOptions = gopacket.SerializeOptions{ComputeChecksums: true}
-		*bonjourPacket.srcIP = spoofAddr
+		*bonjourPacket.srcIP = srcIPAddress
 		// We recalculate the checksum since the IP was modified
 		if parsedIP := bonjourPacket.packet.Layer(layers.LayerTypeIPv4); parsedIP != nil {
 			if parsedUDP := bonjourPacket.packet.Layer(layers.LayerTypeUDP); parsedUDP != nil {

--- a/packet.go
+++ b/packet.go
@@ -42,7 +42,7 @@ func parsePacketsLazily(source *gopacket.PacketSource) chan bonjourPacket {
 
 			// Pass on the packet for its next adventure
 			packetChan <- bonjourPacket{
-			packet:     packet,
+				packet:     packet,
 				vlanTag:    tag,
 				srcMAC:     srcMAC,
 				dstMAC:     dstMAC,
@@ -80,6 +80,7 @@ func parseIPLayer(packet gopacket.Packet) (isIPv6 bool, srcIP *net.IP) {
 		isIPv6 = true
 		srcIP = &parsedIP.(*layers.IPv6).SrcIP
 	}
+	
 	return
 }
 
@@ -102,9 +103,18 @@ type packetWriter interface {
 	WritePacketData([]byte) error
 }
 
-func sendBonjourPacket(handle packetWriter, bonjourPacket *bonjourPacket, tag uint16, brMACAddress net.HardwareAddr, spoofAddr net.IP, spoof bool) {
+func sendBonjourPacket(
+	handle packetWriter,
+	bonjourPacket *bonjourPacket,
+	tag uint16,
+	brMACAddress net.HardwareAddr,
+	srcIPAddress net.IP,
+	spoofsrcIP bool,
+	dstMACAddress net.HardwareAddr) {
 	*bonjourPacket.vlanTag = tag
 	*bonjourPacket.srcMAC = brMACAddress
+	*bonjourPacket.dstMAC = dstMACAddress
+
 	
 	// Network devices may set dstMAC to the local MAC address
 	// Rewrite dstMAC to ensure that it is set to the appropriate multicast MAC address

--- a/packet_test.go
+++ b/packet_test.go
@@ -320,18 +320,18 @@ func TestSendBonjourPacket(t *testing.T) {
 
 	pw := &mockPacketWriter{packet: nil}
 
-	sendBonjourPacket(pw, &bonjourTestPacketIPv4, newVlanTag, brMACTest, spoofAddrTest, false, dstMACTest)
+	sendBonjourPacket(pw, &bonjourTestPacketIPv4, newVlanTag, brMACTest, spoofAddrTest, false, dstMACTest, false)
 	if !reflect.DeepEqual(expectedPacketIPv4.Layers(), pw.packet.Layers()) {
 		t.Error("Error in sendBonjourPacket() for IPv4")
 	}
 	
 	// When we change the src IP address of mDNS Query we expect the IPv4 layer to be different
-	sendBonjourPacket(pw, &bonjourTestPacketIPv4, newVlanTag, brMACTest, spoofAddrTest, true, dstMACTest)
+	sendBonjourPacket(pw, &bonjourTestPacketIPv4, newVlanTag, brMACTest, spoofAddrTest, true, dstMACTest, false)
 	if reflect.DeepEqual(expectedPacketIPv4.Layers(), pw.packet.Layers()) {
 		t.Error("Error in sendBonjourPacket() for IPv4 with spoof address")
 	}
 
-	sendBonjourPacket(pw, &bonjourTestPacketIPv6, newVlanTag, brMACTest, spoofAddrTest, false, dstMACTest)
+	sendBonjourPacket(pw, &bonjourTestPacketIPv6, newVlanTag, brMACTest, spoofAddrTest, false, dstMACTest, false)
 	if !reflect.DeepEqual(expectedPacketIPv6.Layers(), pw.packet.Layers()) {
 		t.Error("Error in sendBonjourPacket() for IPv6")
 	}

--- a/packet_test.go
+++ b/packet_test.go
@@ -320,18 +320,18 @@ func TestSendBonjourPacket(t *testing.T) {
 
 	pw := &mockPacketWriter{packet: nil}
 
-	sendBonjourPacket(pw, &bonjourTestPacketIPv4, newVlanTag, brMACTest, spoofAddrTest, false)
+	sendBonjourPacket(pw, &bonjourTestPacketIPv4, newVlanTag, brMACTest, spoofAddrTest, false, dstMACTest)
 	if !reflect.DeepEqual(expectedPacketIPv4.Layers(), pw.packet.Layers()) {
 		t.Error("Error in sendBonjourPacket() for IPv4")
 	}
 	
 	// When we change the src IP address of mDNS Query we expect the IPv4 layer to be different
-	sendBonjourPacket(pw, &bonjourTestPacketIPv4, newVlanTag, brMACTest, spoofAddrTest, true)
+	sendBonjourPacket(pw, &bonjourTestPacketIPv4, newVlanTag, brMACTest, spoofAddrTest, true, dstMACTest)
 	if reflect.DeepEqual(expectedPacketIPv4.Layers(), pw.packet.Layers()) {
 		t.Error("Error in sendBonjourPacket() for IPv4 with spoof address")
 	}
 
-	sendBonjourPacket(pw, &bonjourTestPacketIPv6, newVlanTag, brMACTest, spoofAddrTest, false)
+	sendBonjourPacket(pw, &bonjourTestPacketIPv6, newVlanTag, brMACTest, spoofAddrTest, false, dstMACTest)
 	if !reflect.DeepEqual(expectedPacketIPv6.Layers(), pw.packet.Layers()) {
 		t.Error("Error in sendBonjourPacket() for IPv6")
 	}


### PR DESCRIPTION
**Description:**
When the aggressive mode is enabled the Bonjour Reflector save the source MAC address of the last MDNS query for the VLAN and when relaying the response from this VLAN's Chromecast it sends a response the the saved MAC address in addition to the Multicast MAC address. 
This is to workaround any type of IGMPv3 snooping that could occur in the AP.

run with `-aggressivemode` to activate

**Reason:**
I have a case with Unifi APs where the devices does not detect the Chromecast even though the mDNS query is responded and sent to the multicast MAC address.
The devices only detects the Chromecast after explicitly registering to the IGMPv3 group for 224.0.0.251